### PR TITLE
Replace TableLayout by GridLayout

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -11,7 +11,8 @@
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
         "3.32",
-        "3.34"
+        "3.34",
+        "3.36"
     ],
     "url": "https://github.com/jasuarez/hamster-shell-extension.git",
     "uuid": "jasuarez@projecthamster.org",

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -46,7 +46,7 @@ class TodaysFactsWidget extends St.ScrollView {
         this.factsBox.set_vertical(true);
         this.facts_widget = new St.Widget({
             style_class: 'hamster-activities',
-            layout_manager: new Clutter.TableLayout(),
+            layout_manager: new Clutter.GridLayout(),
             reactive: true
         });
         this.factsBox.add(this.facts_widget);
@@ -198,7 +198,7 @@ class TodaysFactsWidget extends St.ScrollView {
         for (let fact of facts) {
             let rowComponents = constructRow.bind(this)(fact, ongoingFact, this._controller, this._panelWidget.menu);
             for (let component of rowComponents) {
-                layout.pack(component, rowComponents.indexOf(component), rowCount);
+                layout.attach(component, rowComponents.indexOf(component), rowCount, 1);
             }
             rowCount += 1;
         }


### PR DESCRIPTION
This replaces `Clutter.TableLayout` by `Clutter.GridLayout` and makes the extension work also under Gnome Shell 3.36. See also https://github.com/projecthamster/hamster-shell-extension/pull/323/files#diff-e379f5101fa23d66840e4bf4dd9bb30d.

Probably fixes #2.